### PR TITLE
Arreglos

### DIFF
--- a/doc/02-grammar.json
+++ b/doc/02-grammar.json
@@ -58,7 +58,10 @@
     ["RETURN", "LPAREN", "expressionSeq", "RPAREN"]
   ],
   ["stmtIf",
-    ["IF", "LPAREN", "expression", "RPAREN", ["?", ["THEN"]], "stmtBlock", ["?", ["ELSE", "stmtBlock"]]]
+    ["IF", "stmtIfBranch", ["*", ["ELSE", "IF", "stmtIfBranch"]], ["?", ["ELSE", "stmtBlock"]]]
+  ],
+  ["stmtIfBranch",
+    ["LPAREN", "expression", "RPAREN", ["?", ["THEN"]], "stmtBlock"]
   ],
   ["stmtRepeat",
     ["REPEAT", "LPAREN", "expression", "RPAREN", "stmtBlock"]

--- a/doc/02-grammar.tex
+++ b/doc/02-grammar.tex
@@ -77,7 +77,10 @@
 \token{RETURN} \token{LPAREN} \nonterminal{expressionSeq} \token{RPAREN}
 }
 \production{\nonterminal{stmtIf}}{
-\token{IF} \token{LPAREN} \nonterminal{expression} \token{RPAREN} (\token{THEN})? \nonterminal{stmtBlock} (\token{ELSE} \nonterminal{stmtBlock})?
+\token{IF} \nonterminal{stmtIfBranch} (\token{ELSE} \token{IF} \nonterminal{stmtIfBranch})* (\token{ELSE} \nonterminal{stmtBlock})?
+}
+\production{\nonterminal{stmtIfBranch}}{
+\token{LPAREN} \nonterminal{expression} \token{RPAREN} (\token{THEN})? \nonterminal{stmtBlock}
 }
 \production{\nonterminal{stmtRepeat}}{
 \token{REPEAT} \token{LPAREN} \nonterminal{expression} \token{RPAREN} \nonterminal{stmtBlock}

--- a/doc/gobstones.tex
+++ b/doc/gobstones.tex
@@ -15,7 +15,7 @@
 \newcommand{\nonEmpty}[1]{#1$_{1}$}
 \newcommand{\production}[2]{
   \noindent
-  \begin{tabular}{lrl}
+  \begin{tabular}{lrp{10cm}}
   #1 & $\xrightarrow{\hspace{.5cm}}$ & #2
   \end{tabular}\\
 }
@@ -550,7 +550,11 @@ tienen asociados dos atributos booleanos:
 \end{itemize}
 Se aplican las siguientes reglas:
 \begin{itemize}
-\item El \texttt{program} es siempre \texttt{recorded} y nunca \texttt{atomic}.
+\item El \texttt{program} nunca \texttt{atomic}.
+      Además el \texttt{program} {\bf no} es \texttt{recorded}:
+      se toma una {\em snapshot} al comienzo del \texttt{program},
+      pero no al final. La \'ultima {\em snapshot} será la
+      ocasionada por el \'ultimo comando que tenga el atributo \texttt{recorded}.
 \item Las funciones nunca son \texttt{recorded} y siempre son \texttt{atomic}.
       (Los efectos que se producen durante la ejecuci\'on de una funci\'on
       son invisibles desde el exterior, de manera que cualquier cambio en el estado

--- a/src/board_formats.js
+++ b/src/board_formats.js
@@ -213,7 +213,7 @@ export function gbbToJboard(gbb) {
 
   function skipWhitespace() {
     /* Skip whitespace */
-    if (i < gbb.length && isWhitespace(gbb[i])) {
+    while (i < gbb.length && isWhitespace(gbb[i])) {
       i++;
     }
   }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -524,6 +524,9 @@ const LOCALE_ES = {
   'CONS:Dir2': 'Sur',
   'CONS:Dir3': 'Oeste',
 
+  'PRIM:BOOM': 'BOOM',
+  'PRIM:boom': 'boom',
+
   'PRIM:PutStone': 'Poner',
   'PRIM:RemoveStone': 'Sacar',
   'PRIM:Move': 'Mover',

--- a/src/parser.js
+++ b/src/parser.js
@@ -417,6 +417,7 @@ export class Parser {
   _parseStmtIf() {
     let startPos = this._currentToken.startPos;
     this._match(T_IF);
+
     this._match(T_LPAREN);
     let condition = this._parseExpression();
     this._match(T_RPAREN);
@@ -425,11 +426,16 @@ export class Parser {
       this._match(T_THEN);
     }
     let thenBlock = this._parseStmtBlock();
+
     let endPos;
     let elseBlock;
     if (this._currentToken.tag === T_ELSE) {
       this._match(T_ELSE);
-      elseBlock = this._parseStmtBlock();
+      if (this._currentToken.tag === T_IF) {
+        elseBlock = this._parseStmtIf();
+      } else {
+        elseBlock = this._parseStmtBlock();
+      }
       endPos = elseBlock.endPos;
     } else {
       elseBlock = null;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -688,6 +688,14 @@ export class RuntimePrimitives {
         }
       );
 
+    this._primitiveFunctions['not'] =
+      new PrimitiveOperation(
+        [typeBool], noValidation,
+        function (globalState, x) {
+          return valueFromBool(!boolFromValue(x));
+        }
+      );
+
     this._primitiveFunctions['&&'] =
       new PrimitiveOperation(
         [typeAny, typeAny], noValidation,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1031,6 +1031,22 @@ export class RuntimePrimitives {
         }
       );
 
+    /* User-triggered failure */
+
+    this._primitiveProcedures[i18n('PRIM:BOOM')] =
+      new PrimitiveOperation(
+        [typeString],
+        function (startPos, endPos, globalState, args) {
+          fail(startPos, endPos, 'boom-called', [args[0].string]);
+        },
+        function (globalState, msg) {
+          throw Error('Should not be reachable.');
+        }
+      );
+
+    this._primitiveFunctions[i18n('PRIM:boom')] =
+      this._primitiveProcedures[i18n('PRIM:BOOM')];
+
     /* List opreators */
     this._primitiveFunctions['++'] =
       new PrimitiveOperation(

--- a/test/03.parser.statements.spec.js
+++ b/test/03.parser.statements.spec.js
@@ -492,6 +492,132 @@ describe('Parser: statements', () => {
       expect(ast[0].body.statements[1].endPos.column).equals(38);
     });
 
+    it('Accept "if" with "else if" without "else"', () => {
+      let parser = new Parser([
+          'program {',
+          '  if (a) {',
+          '    A()',
+          '  } else if (b) {',
+          '    B()',
+          '  }',
+          '}',
+      ].join('\n'));
+      expectAST(parser.parse(), [
+        new ASTDefProgram(
+          new ASTStmtBlock([
+            new ASTStmtIf(
+              new ASTExprVariable(tok(T_LOWERID, 'a')),
+              new ASTStmtBlock([
+                  new ASTStmtProcedureCall(tok(T_UPPERID, 'A'), [])
+              ]),
+              new ASTStmtIf(
+                new ASTExprVariable(tok(T_LOWERID, 'b')),
+                new ASTStmtBlock([
+                  new ASTStmtProcedureCall(tok(T_UPPERID, 'B'), [])
+                ]),
+                null,
+              ),
+            )
+          ])
+        )
+      ]);
+    });
+
+    it('Accept "if" with "else if" with "else"', () => {
+      let parser = new Parser([
+          'program {',
+          '  if (a) {',
+          '    A()',
+          '  } else if (b) then {',
+          '    B()',
+          '  } else {',
+          '    C()',
+          '  }',
+          '}',
+      ].join('\n'));
+      expectAST(parser.parse(), [
+        new ASTDefProgram(
+          new ASTStmtBlock([
+            new ASTStmtIf(
+              new ASTExprVariable(tok(T_LOWERID, 'a')),
+              new ASTStmtBlock([
+                new ASTStmtProcedureCall(tok(T_UPPERID, 'A'), [])
+              ]),
+              new ASTStmtIf(
+                new ASTExprVariable(tok(T_LOWERID, 'b')),
+                new ASTStmtBlock([
+                  new ASTStmtProcedureCall(tok(T_UPPERID, 'B'), [])
+                ]),
+                new ASTStmtBlock([
+                  new ASTStmtProcedureCall(tok(T_UPPERID, 'C'), [])
+                ])
+              ),
+            )
+          ])
+        )
+      ]);
+    });
+
+    it('Accept chain of "else if"s', () => {
+      let parser = new Parser([
+          'program {',
+          '  if (a) {',
+          '    A()',
+          '  } else if (b) then {',
+          '    B()',
+          '  } else if (c) then {',
+          '    C()',
+          '  } else if (d) then {',
+          '    D()',
+          '  } else if (e) then {',
+          '    E()',
+          '  } else {',
+          '    F()',
+          '  }',
+          '}',
+      ].join('\n'));
+      expectAST(parser.parse(), [
+        new ASTDefProgram(
+          new ASTStmtBlock([
+            new ASTStmtIf(
+              new ASTExprVariable(tok(T_LOWERID, 'a')),
+              new ASTStmtBlock([
+                new ASTStmtProcedureCall(tok(T_UPPERID, 'A'), [])
+              ]),
+              new ASTStmtIf(
+                new ASTExprVariable(tok(T_LOWERID, 'b')),
+                new ASTStmtBlock([
+                  new ASTStmtProcedureCall(tok(T_UPPERID, 'B'), [])
+                ]),
+
+                new ASTStmtIf(
+                  new ASTExprVariable(tok(T_LOWERID, 'c')),
+                  new ASTStmtBlock([
+                    new ASTStmtProcedureCall(tok(T_UPPERID, 'C'), [])
+                  ]),
+                  new ASTStmtIf(
+                    new ASTExprVariable(tok(T_LOWERID, 'd')),
+                    new ASTStmtBlock([
+                      new ASTStmtProcedureCall(tok(T_UPPERID, 'D'), [])
+                    ]),
+                    new ASTStmtIf(
+                      new ASTExprVariable(tok(T_LOWERID, 'e')),
+                      new ASTStmtBlock([
+                        new ASTStmtProcedureCall(tok(T_UPPERID, 'E'), [])
+                      ]),
+                      new ASTStmtBlock([
+                        new ASTStmtProcedureCall(tok(T_UPPERID, 'F'), [])
+                      ]),
+                    ),
+                  ),
+                ),
+              ),
+            )
+          ])
+        )
+      ]);
+    });
+
   });
 
   describe('Foreach statement', () => {

--- a/test/07.compiler.spec.js
+++ b/test/07.compiler.spec.js
@@ -160,6 +160,58 @@ describe('Compiler', () => {
       );
     });
 
+    it('Chain of "else if"s', () => {
+      let result = new Runner().run([
+        'function f(x) {',
+        '  if (x == 1) {',
+        '    y := "a"',
+        '  } else if (x == 2) {',
+        '    y := "b"',
+        '  } else if (x == 3) {',
+        '    y := "c"',
+        '  } else {',
+        '    y := "d"',
+        '  }',
+        '  return (y)',
+        '}',
+        'function g(x) {',
+        '  y := "D"',
+        '  if (x == 1) {',
+        '    y := "A"',
+        '  } else if (x == 2) {',
+        '    y := "B"',
+        '  } else if (x == 3) {',
+        '    y := "C"',
+        '  }',
+        '  return (y)',
+        '}',
+        'program {',
+        '  return (',
+        '    (f(1), f(2), f(3), f(4))',
+        '  ,',
+        '    (g(1), g(2), g(3), g(4))',
+        '  )',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(
+        new ValueTuple([
+          new ValueTuple([
+            new ValueString("a"),
+            new ValueString("b"),
+            new ValueString("c"),
+            new ValueString("d"),
+          ]),
+          new ValueTuple([
+            new ValueString("A"),
+            new ValueString("B"),
+            new ValueString("C"),
+            new ValueString("D"),
+          ]),
+        ])
+      );
+    });
+
+
   });
 
   describe('Statements: repeat', () => {

--- a/test/09.builtins.spec.js
+++ b/test/09.builtins.spec.js
@@ -1298,6 +1298,28 @@ describe('Primitive functions, procedures and operators', () => {
 
   });
 
+  describe('User-triggered failure (BOOM and boom)', () => {
+
+    it('"BOOM" procedure should fail', () => {
+      let result = () => new Runner().run([
+        'program {',
+        '  ' + i18n('PRIM:BOOM') + '("foo")',
+        '}'
+      ].join('\n'));
+      expect(result).throws("foo");
+    });
+
+    it('"boom" function should fail', () => {
+      let result = () => new Runner().run([
+        'program {',
+        '  x := ' + i18n('PRIM:boom') + '("foo")',
+        '}'
+      ].join('\n'));
+      expect(result).throws("foo");
+    });
+
+  });
+
   describe('Gobstones board operations', () => {
 
     function runState(code) {

--- a/test/09.builtins.spec.js
+++ b/test/09.builtins.spec.js
@@ -1000,6 +1000,51 @@ describe('Primitive functions, procedures and operators', () => {
       );
     });
   });
+    
+  describe('Logical operators', () => {
+    /* Note: conjunction and disjunction are checked in 07.compiler.spec.js
+     * since they are treated distinctly, for they are short-circuiting.
+     */
+    it('Negation', () => {
+      let result = new Runner().run([
+        'program {',
+        '  return (',
+        '    not ' + i18n('CONS:False') + ',',
+        '    not ' + i18n('CONS:True') + ',',
+        '    not not ' + i18n('CONS:False') + ',',
+        '    not not ' + i18n('CONS:True'),
+        '  )',
+        '}',
+      ].join('\n'));
+
+      expect(result).deep.equals(
+        new ValueTuple([
+          new ValueStructure(i18n('TYPE:Bool'), i18n('CONS:True'), {}),
+          new ValueStructure(i18n('TYPE:Bool'), i18n('CONS:False'), {}),
+          new ValueStructure(i18n('TYPE:Bool'), i18n('CONS:False'), {}),
+          new ValueStructure(i18n('TYPE:Bool'), i18n('CONS:True'), {}),
+        ])
+      );
+
+    });
+
+    it('Negation: check type', () => {
+      let result = () => new Runner().run([
+        'program {',
+        '  return (not 1)',
+        '}',
+      ].join('\n'));
+      expect(result).throws(
+        i18n('errmsg:primitive-argument-type-mismatch')(
+          'not',
+          1,
+          i18n('TYPE:Bool'),
+          i18n('TYPE:Integer'),
+        )
+      );
+    });
+
+  });
 
   describe('Arithmetic operators', () => {
 

--- a/test/10.api.spec.js
+++ b/test/10.api.spec.js
@@ -262,7 +262,7 @@ describe('Gobstones API', () => {
 
   describe('Snapshots', () => {
 
-    it('Snapshots', () => {
+    it('Take snapshots', () => {
         let p = API().parse([
           'procedure P() {',
           '  Poner(Azul)',
@@ -276,11 +276,12 @@ describe('Gobstones API', () => {
           '  Poner(Verde)',
           '  P()',
           '  Poner(Verde)',
+          '  P()',
           '}',
         ].join('\n'));
         let r = p.program.interpret(emptyBoard(1, 1));
         let s = r.snapshots
-        expect(s.length).equals(7);
+        expect(s.length).equals(9);
 
         expect(s[0].contextNames).deep.equals(['program']);
         expect(s[0].board.table[0][0]).deep.equals({});
@@ -291,17 +292,44 @@ describe('Gobstones API', () => {
         expect(s[2].contextNames).deep.equals(['program', 'P-1']);
         expect(s[2].board.table[0][0]).deep.equals({green: 1, blue: 1});
 
-        expect(s[3].contextNames).deep.equals(['program', 'P-2', 'Q-3']);
+        expect(s[3].contextNames).deep.equals(['program', 'P-1', 'Q-2']);
         expect(s[3].board.table[0][0]).deep.equals({green: 1, blue: 2});
 
-        expect(s[4].contextNames).deep.equals(['program', 'P-4']);
+        expect(s[4].contextNames).deep.equals(['program', 'P-1']);
         expect(s[4].board.table[0][0]).deep.equals({green: 1, blue: 3});
 
         expect(s[5].contextNames).deep.equals(['program']);
         expect(s[5].board.table[0][0]).deep.equals({green: 2, blue: 3});
 
-        expect(s[6].contextNames).deep.equals(['program']);
-        expect(s[6].board.table[0][0]).deep.equals({green: 2, blue: 3});
+        expect(s[6].contextNames).deep.equals(['program', 'P-3']);
+        expect(s[6].board.table[0][0]).deep.equals({green: 2, blue: 4});
+
+        expect(s[7].contextNames).deep.equals(['program', 'P-3', 'Q-4']);
+        expect(s[7].board.table[0][0]).deep.equals({green: 2, blue: 5});
+
+        expect(s[8].contextNames).deep.equals(['program', 'P-3']);
+        expect(s[8].board.table[0][0]).deep.equals({green: 2, blue: 6});
+
+    });
+
+    it('Take snapshots on failing program', () => {
+        let p = API().parse([
+          'program {',
+          '  Poner(Azul)',
+          '  Poner(Azul)',
+          '  Poner(Azul)',
+          '  BOOM("stop")',
+          '  Poner(Rojo)',
+          '}',
+        ].join('\n'));
+        let r = p.program.interpret(emptyBoard(1, 1));
+        expect(r.reason.code).equals('boom-called');
+        let s = r.snapshots;
+        expect(s.length).equals(4);
+        expect(s[0].board.table[0][0]).deep.equals({});
+        expect(s[1].board.table[0][0]).deep.equals({blue: 1});
+        expect(s[2].board.table[0][0]).deep.equals({blue: 2});
+        expect(s[3].board.table[0][0]).deep.equals({blue: 3});
     });
 
     it('Ignore snapshots inside an atomic routine', () => {
@@ -318,13 +346,10 @@ describe('Gobstones API', () => {
         ].join('\n'));
         let r = p.program.interpret(emptyBoard(1, 1));
         let s = r.snapshots
-        expect(s.length).equals(2);
+        expect(s.length).equals(1);
 
         expect(s[0].contextNames).deep.equals(['program']);
         expect(s[0].board.table[0][0]).deep.equals({});
-
-        expect(s[1].contextNames).deep.equals(['program']);
-        expect(s[1].board.table[0][0]).deep.equals({});
     });
 
   });

--- a/test/10.api.spec.js
+++ b/test/10.api.spec.js
@@ -251,6 +251,13 @@ describe('Gobstones API', () => {
       expect(r.on.range.end.column).equals(23);
     });
 
+    it('Run a program with a user-triggered runtime error', () => {
+      let p = API().parse('program { BOOM("foo") }');
+      let r = p.program.interpret(emptyBoard(1, 1));
+      expect(r.reason.code).equals('boom-called');
+      expect(r.reason.detail).deep.equals(["foo"]);
+    });
+
   });
 
   describe('Snapshots', () => {

--- a/test/10.api.spec.js
+++ b/test/10.api.spec.js
@@ -521,6 +521,15 @@ describe('Gobstones API', () => {
       });
     });
 
+    it('GBB to apiboard: allow Window newlines', () => {
+        let board = API().gbb.read('GBB/1.0\r\nsize 1 1');
+       expect(board).deep.equals({
+         width: 1, height: 1,
+         head: {x: 0, y: 0},
+         table: [[{}]]
+       });
+    });
+
     it('Apiboard to GBB', () => {
       let apiboard = {
         width: 6, height: 3,


### PR DESCRIPTION
1. Se agregó la primitiva `not` (issue #13).

2. Se agregó el problema de lectura de tableros GBB (issue #12). (Yo también sospechaba que el error tenía que ver con el fin de línea de Windows, pero era un bug mucho más grosero: el parser de GBB solamente ignoraba secuencias de whitespace de largo 1 y fallaba con secuencias más largas).

3. Se arreglaron los nombres de contexto de snapshots y se eliminó el snapshot final generado por el program (issue #11). También se agregó la lista de snapshots en la API en caso de que el programa falle y se retorne una `ExecutionError`. Este cambio había sido implementado por @rodri042 [comunicación personal] ;-)

4. Se agregaron el procedimiento primitivo `BOOM` y la función primitiva `boom`, que fallan cuando se los invoca con un string como parámetro.

5. Se agregó soporte para el `else if`. Sintaxis: `if <alternativa> [else if <alternativa>]* [else <bloque>]?` donde `<alternativa> ::= ( <expresión> ) [then]? <bloque>`.