### PR TITLE
Fixed translation of 'init' and 'last' which was backwards

### DIFF
--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -686,8 +686,8 @@ export const LOCALE_ES = {
 
   'PRIM:head': 'primero',
   'PRIM:tail': 'resto',
-  'PRIM:init': 'ultimo',
-  'PRIM:last': 'comienzo',
+  'PRIM:init': 'comienzo',
+  'PRIM:last': 'ultimo',
 
   /* Helpers */
   '<alternative>':

--- a/src/i18n/pt.js
+++ b/src/i18n/pt.js
@@ -547,8 +547,8 @@ LOCALE_PT['PRIM:maxDir'] = 'maxDir';
 
 LOCALE_PT['PRIM:head'] = 'primeiro';
 LOCALE_PT['PRIM:tail'] = 'resto';
-LOCALE_PT['PRIM:init'] = 'ultimo';
-LOCALE_PT['PRIM:last'] = 'comeco';
+LOCALE_PT['PRIM:init'] = 'comeco';
+LOCALE_PT['PRIM:last'] = 'ultimo';
 
 /* Helpers */
 LOCALE_PT['<alternative>'] =


### PR DESCRIPTION
Se arreglaron las traducciones de `init` y `last` que estababan al revés tanto en castellano como en portugués.