### PR TITLE
Versión destructuring del foreach y elipsis

### DIFF
--- a/doc/01-tokens.json
+++ b/doc/01-tokens.json
@@ -41,6 +41,7 @@
   ["symbol", "]", "RBRACK", "Corchete derecho."],
   ["symbol", ",", "COMMA", "Coma."],
   ["symbol", ";", "SEMICOLON", "Punto y coma (separador de instrucciones opcional)."],
+  ["symbol", "...", "ELLIPSIS", "Fragmento de programa intencionalmente incompleto."],
   ["symbol", "..", "RANGE", "Para rangos."],
   ["symbol", ":=", "ASSIGN", "Asignación."],
   ["symbol", "&&", "AND", "Conjunción."],

--- a/doc/01-tokens.tex
+++ b/doc/01-tokens.tex
@@ -44,6 +44,7 @@
 \texttt{]} & \token{RBRACK} & Corchete derecho. \\
 \texttt{,} & \token{COMMA} & Coma. \\
 \texttt{;} & \token{SEMICOLON} & Punto y coma (separador de instrucciones opcional). \\
+\texttt{...} & \token{ELLIPSIS} & Fragmento de programa intencionalmente incompleto. \\
 \texttt{..} & \token{RANGE} & Para rangos. \\
 \texttt{:=} & \token{ASSIGN} & Asignaci\'on. \\
 \texttt{\&\&} & \token{AND} & Conjunci\'on. \\

--- a/doc/02-grammar.json
+++ b/doc/02-grammar.json
@@ -67,7 +67,7 @@
     ["REPEAT", "LPAREN", "expression", "RPAREN", "stmtBlock"]
   ],
   ["stmtForeach",
-    ["FOREACH", "pattern", "IN", "expression", "stmtBlock"]
+    ["FOREACH", "LOWERID", "IN", "expression", "stmtBlock"]
   ],
   ["stmtWhile",
     ["WHILE", "LPAREN", "expression", "RPAREN", "stmtBlock"]

--- a/doc/02-grammar.json
+++ b/doc/02-grammar.json
@@ -67,7 +67,7 @@
     ["REPEAT", "LPAREN", "expression", "RPAREN", "stmtBlock"]
   ],
   ["stmtForeach",
-    ["FOREACH", "LOWERID", "IN", "expression", "stmtBlock"]
+    ["FOREACH", "pattern", "IN", "expression", "stmtBlock"]
   ],
   ["stmtWhile",
     ["WHILE", "LPAREN", "expression", "RPAREN", "stmtBlock"]
@@ -94,6 +94,7 @@
   ],
   ["pattern",
     ["patternWildcard"],
+    ["patternVariable"],
     ["patternNumber"],
     ["patternStructure"],
     ["patternTuple"],
@@ -101,6 +102,9 @@
   ],
   ["patternWildcard",
     ["UNDERSCORE"]
+  ],
+  ["patternVariable",
+    ["LOWERID"]
   ],
   ["patternNumber",
     ["NUM"],

--- a/doc/02-grammar.json
+++ b/doc/02-grammar.json
@@ -40,6 +40,7 @@
     ["LOWERID", ["?", ["COMMA", "nonEmptyLoweridSeq"]]]
   ],
   ["statement",
+    ["stmtEllipsis"],
     ["stmtBlock"],
     ["stmtReturn"],
     ["stmtIf"],
@@ -50,6 +51,9 @@
     ["stmtLet"],
     ["stmtVariableAssignment"],
     ["stmtProcedureCall"]
+  ],
+  ["stmtEllipsis",
+    ["ELLIPSIS"]
   ],
   ["stmtBlock",
     ["LBRACE", ["*", ["statement", ["?", ["SEMICOLON"]]]], "RBRACE"]
@@ -127,6 +131,7 @@
     ["LPAREN", "expression", "RPAREN"]
   ],
   ["exprAtom",
+    ["exprEllipsis"],
     ["exprVariable"],
     ["exprFunctionCall"],
     ["exprConstantNumber"],
@@ -137,6 +142,9 @@
     ["exprTuple"],
     ["exprStructure"],
     ["exprStructureUpdate"]
+  ],
+  ["exprEllipsis",
+    ["ELLIPSIS"]
   ],
   ["exprVariable",
     ["LOWERID"]

--- a/doc/02-grammar.json
+++ b/doc/02-grammar.json
@@ -67,7 +67,7 @@
     ["REPEAT", "LPAREN", "expression", "RPAREN", "stmtBlock"]
   ],
   ["stmtForeach",
-    ["FOREACH", "LOWERID", "IN", "expression", "stmtBlock"]
+    ["FOREACH", "pattern", "IN", "expression", "stmtBlock"]
   ],
   ["stmtWhile",
     ["WHILE", "LPAREN", "expression", "RPAREN", "stmtBlock"]

--- a/doc/02-grammar.tex
+++ b/doc/02-grammar.tex
@@ -50,6 +50,8 @@
 \token{LOWERID} (\token{COMMA} \nonterminal{\nonEmpty{loweridSeq}})?
 }
 \production{\nonterminal{statement}}{
+\nonterminal{stmtEllipsis}
+\ALT
 \nonterminal{stmtBlock}
 \ALT
 \nonterminal{stmtReturn}
@@ -70,6 +72,9 @@
 \ALT
 \nonterminal{stmtProcedureCall}
 }
+\production{\nonterminal{stmtEllipsis}}{
+\token{ELLIPSIS}
+}
 \production{\nonterminal{stmtBlock}}{
 \token{LBRACE} (\nonterminal{statement} (\token{SEMICOLON})?)* \token{RBRACE}
 }
@@ -86,7 +91,7 @@
 \token{REPEAT} \token{LPAREN} \nonterminal{expression} \token{RPAREN} \nonterminal{stmtBlock}
 }
 \production{\nonterminal{stmtForeach}}{
-\token{FOREACH} \token{LOWERID} \token{IN} \nonterminal{expression} \nonterminal{stmtBlock}
+\token{FOREACH} \nonterminal{pattern} \token{IN} \nonterminal{expression} \nonterminal{stmtBlock}
 }
 \production{\nonterminal{stmtWhile}}{
 \token{WHILE} \token{LPAREN} \nonterminal{expression} \token{RPAREN} \nonterminal{stmtBlock}
@@ -158,6 +163,8 @@
 \token{LPAREN} \nonterminal{expression} \token{RPAREN}
 }
 \production{\nonterminal{exprAtom}}{
+\nonterminal{exprEllipsis}
+\ALT
 \nonterminal{exprVariable}
 \ALT
 \nonterminal{exprFunctionCall}
@@ -177,6 +184,9 @@
 \nonterminal{exprStructure}
 \ALT
 \nonterminal{exprStructureUpdate}
+}
+\production{\nonterminal{exprEllipsis}}{
+\token{ELLIPSIS}
 }
 \production{\nonterminal{exprVariable}}{
 \token{LOWERID}

--- a/doc/02-grammar.tex
+++ b/doc/02-grammar.tex
@@ -86,7 +86,7 @@
 \token{REPEAT} \token{LPAREN} \nonterminal{expression} \token{RPAREN} \nonterminal{stmtBlock}
 }
 \production{\nonterminal{stmtForeach}}{
-\token{FOREACH} \token{LOWERID} \token{IN} \nonterminal{expression} \nonterminal{stmtBlock}
+\token{FOREACH} \nonterminal{pattern} \token{IN} \nonterminal{expression} \nonterminal{stmtBlock}
 }
 \production{\nonterminal{stmtWhile}}{
 \token{WHILE} \token{LPAREN} \nonterminal{expression} \token{RPAREN} \nonterminal{stmtBlock}
@@ -116,6 +116,8 @@
 \production{\nonterminal{pattern}}{
 \nonterminal{patternWildcard}
 \ALT
+\nonterminal{patternVariable}
+\ALT
 \nonterminal{patternNumber}
 \ALT
 \nonterminal{patternStructure}
@@ -126,6 +128,9 @@
 }
 \production{\nonterminal{patternWildcard}}{
 \token{UNDERSCORE}
+}
+\production{\nonterminal{patternVariable}}{
+\token{LOWERID}
 }
 \production{\nonterminal{patternNumber}}{
 \token{NUM}
@@ -186,7 +191,7 @@
 \token{STRING}
 }
 \production{\nonterminal{exprChoose}}{
-\token{CHOOSE} (\nonterminal{expression} \token{WHEN} \token{LPAREN} \nonterminal{expression} \token{RPAREN})+ \nonterminal{expression} \token{OTHERWISE}
+\token{CHOOSE} (\nonterminal{expression} \token{WHEN} \token{LPAREN} \nonterminal{expression} \token{RPAREN})* \nonterminal{expression} \token{OTHERWISE}
 }
 \production{\nonterminal{exprList}}{
 \token{LBRACK} \nonterminal{expressionSeq} \token{RBRACK}

--- a/doc/02-grammar.tex
+++ b/doc/02-grammar.tex
@@ -86,7 +86,7 @@
 \token{REPEAT} \token{LPAREN} \nonterminal{expression} \token{RPAREN} \nonterminal{stmtBlock}
 }
 \production{\nonterminal{stmtForeach}}{
-\token{FOREACH} \nonterminal{pattern} \token{IN} \nonterminal{expression} \nonterminal{stmtBlock}
+\token{FOREACH} \token{LOWERID} \token{IN} \nonterminal{expression} \nonterminal{stmtBlock}
 }
 \production{\nonterminal{stmtWhile}}{
 \token{WHILE} \token{LPAREN} \nonterminal{expression} \token{RPAREN} \nonterminal{stmtBlock}

--- a/doc/03-ast.json
+++ b/doc/03-ast.json
@@ -29,6 +29,7 @@
   ],
   ["data", "Pattern",
     ["PatternWildcard"],
+    ["PatternVariable", ["variableName", "ID"]],
     ["PatternNumber", ["number", "NUM"]],
     ["PatternStructure", ["constructorName", "ID"], ["parameters", ["*", "ID"]]],
     ["PatternTuple", ["parameters", ["*", "ID"]]],

--- a/doc/03-ast.json
+++ b/doc/03-ast.json
@@ -17,7 +17,7 @@
     ["StmtReturn", ["result", "Expression"]],
     ["StmtIf", ["condition", "Expression"], ["thenBlock", "Statement"], ["elseBlock", ["?", "Statement"]]],
     ["StmtRepeat", ["times", "Expression"], ["body", "Statement"]],
-    ["StmtForeach", ["index", "ID"], ["range", "Expression"], ["body", "Statement"]],
+    ["StmtForeach", ["pattern", "Pattern"], ["range", "Expression"], ["body", "Statement"]],
     ["StmtWhile", ["condition", "Expression"], ["body", "Statement"]],
     ["StmtSwitch", ["subject", "Expression"], ["branches", ["*", "SwitchBranch"]]],
     ["StmtAssignVariable", ["variable", "ID"], ["value", "Expression"]],

--- a/doc/03-ast.tex
+++ b/doc/03-ast.tex
@@ -23,7 +23,7 @@
 \ALT
 \ast{StmtRepeat}(times : \type{Expression}, body : \type{Statement})
 \ALT
-\ast{StmtForeach}(index : \type{ID}, range : \type{Expression}, body : \type{Statement})
+\ast{StmtForeach}(pattern : \type{Pattern}, range : \type{Expression}, body : \type{Statement})
 \ALT
 \ast{StmtWhile}(condition : \type{Expression}, body : \type{Statement})
 \ALT

--- a/doc/03-ast.tex
+++ b/doc/03-ast.tex
@@ -37,6 +37,8 @@
 \datadecl{\type{SwitchBranch}}{\ast{SwitchBranch}(pattern : \type{Pattern}, body : \type{Statement})}
 \datadecl{\type{Pattern}}{\ast{PatternWildcard}()
 \ALT
+\ast{PatternVariable}(variableName : \type{ID})
+\ALT
 \ast{PatternNumber}(number : \type{NUM})
 \ALT
 \ast{PatternStructure}(constructorName : \type{ID}, parameters : [\type{ID}])

--- a/doc/gobstones.tex
+++ b/doc/gobstones.tex
@@ -418,9 +418,14 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
   \begin{itemize}
   \item Par\'ametros --- est\'an ligados en la lista de par\'ametros de
         un procedimiento, o en la lista de par\'ametros de una funci\'on, 
-        o en la lista de par\'ametros de un constructor al hacer {\em pattern matching}
-        con \texttt{switch} (por ejemplo los par\'ametros \texttt{x} e \texttt{y} en
-        el comando \texttt{switch (c) \{ Coord(x, y) -> ... \}})
+        o en la lista de variables ligadas al hacer {\em pattern matching}
+        con \texttt{switch}. Por ejemplo \texttt{x} e \texttt{y} son par\'ametros
+        en los comandos:
+        \begin{enumerate}
+        \item \texttt{switch (c) \{ Coord(x, y) ->\ ... \}}
+        \item \texttt{switch (c) \{ (x, y) ->\ ... \}}
+        \item \texttt{switch (c) \{ x ->\ ... \}}
+        \end{enumerate}
   \item \'Indices --- est\'an ligados por un \texttt{foreach}.
   \item Variables --- su valor se declara en una asignaci\'on \texttt{x := e} o en una asignaci\'on
         a una tupla \texttt{(x1, ..., xN) := e}.
@@ -458,6 +463,16 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
   \item Patr\'on tupla (\texttt{(x$_1$, ..., x$_n$)}).
   \item Patr\'on timeout (\texttt{TIMEOUT($n$)}).
   \end{enumerate}
+\item Actualmente los patrones se pueden utilizar en tres lugares:
+      \begin{enumerate}
+      \item en las ramas de un \texttt{interactive program},
+      \item en las ramas de un \texttt{switch},
+      \item como patr\'on de un \texttt{foreach},
+            siempre y cuando la opci\'on \texttt{DestructuringForeach}
+            haya sido habilitada con la directiva \texttt{/*@LANGUAGE@DestructuringForeach@*/}.
+            De lo contrario, el patr\'on de un \texttt{foreach}
+            puede ser \'unicamente un patr\'on variable (\'indice).
+      \end{enumerate}
 \item En un patr\'on estructura, el nombre del constructor en cuesti\'on \DEBE ser un constructor existente de
       alg\'un tipo.
 \item En un patr\'on estructura, el constructor \PUEDE tener $0$ par\'ametros, independientemente del n\'umero
@@ -497,13 +512,16 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
       \DEBEN ser eventos, es decir:
       patrones timeout,
       patrones estructura del tipo \texttt{\_EVENT},
+      patrones variable
       o patrones comod\'in.
 \item Los patrones de las ramas de los \texttt{switch} \NOPUEDEN ser eventos, es decir:
       pueden ser
       patrones num\'ericos,
       patrones estructura de tipos que no sean \texttt{\_EVENT},
       patrones tupla,
+      patrones variable,
       o patrones comod\'in.
+\item El patr\'on de un \texttt{foreach} \NOPUEDE ser un evento. \TODO{TBI}
 \end{itemize}
 
 {\bf Expresiones.}

--- a/doc/gobstones.tex
+++ b/doc/gobstones.tex
@@ -133,7 +133,9 @@ Todos los s\'imbolos terminales se acompa\~nan de su nombre \token{EN\_MAYUSCULA
 
 \subsection{Pragmas}
 
-El tokenizador implementa directivas pragma para
+\subsubsection{Pragmas \texttt{BEGIN\_REGION} y \texttt{END\_REGION}}
+
+Las directivas \texttt{BEGIN\_REGION} y \texttt{END\_REGION} sirven para
 mantener registro de ``regiones''. Una regi\'on es una cadena de texto que
 sirve para identificar o {\em taggear} un fragmento del programa.
 Las regiones no tienen ning\'un significado
@@ -142,9 +144,9 @@ eleva el int\'erprete vienen acompa\~nadas de una posici\'on que incluye
 el nombre de la regi\'on actual. Las regiones pueden anidarse.
 Este comportamiento se implementa por medio de dos directivas.
 \begin{itemize}
-\item \str{/*@BEGIN\_REGION@\textit{nombre\_de\_la\_regi\'on}@*/}:
+\item \str{/*@BEGIN\_REGION@\textit{nombre\_de\_la\_regi\'on}@*/} ---
        mete el nombre de una regi\'on en la pila de regiones.
-\item \str{/*@END\_REGION@*/}: saca la regi\'on del tope de la pila de regiones.
+\item \str{/*@END\_REGION@*/} --- saca la regi\'on del tope de la pila de regiones.
 \end{itemize}
 Por ejemplo ante el siguiente programa:
 \begin{verbatim}
@@ -157,6 +159,76 @@ procedure P() {
 /*@END_REGION@*/
 \end{verbatim}
 El parser idealmente deber\'ia reportar que hay un error de sintaxis en la regi\'on \texttt{B}.
+
+\subsubsection{Pragma \texttt{ATTRIBUTE}}
+
+La directiva \texttt{ATTRIBUTE} sirve para decorar definiciones de
+tipos, programas, procedimientos y funciones con atributos clave/valor.
+La directiva \texttt{ATTRIBUTE} debe {\bf preceder} inmediatamente la definici\'on
+de un tipo, programa, procedimiento o funci\'on, y su sintaxis es la siguiente:
+\begin{itemize}
+\item \str{/*@ATTRIBUTE@clave@valor@*/} --- asocia el valor indicado a la clave indicada.
+      Las claves y valores son {\em strings}.
+\end{itemize}
+Una definici\'on de tipo, programa, procedimiento o funci\'on puede estar precedida
+de varias directivas \texttt{ATTRIBUTE}, asociando a dicha definici\'on un diccionario
+de atributos. Por ejemplo en el siguiente programa:
+\begin{verbatim}
+/*@ATTRIBUTE@descripcion@Poner una piedra en la casilla actual.@*/
+/*@ATTRIBUTE@esAtomico@SI@*/
+procedure PonerPiedra() {
+  ...
+}
+
+/*@ATTRIBUTE@esAtomico@NO@*/
+function f() {
+  ...
+}
+
+/*@ATTRIBUTE@descripcion@Programa principal.@*/
+program {
+  ...
+}
+\end{verbatim}
+El procedimiento \texttt{PonerPiedra} tiene asociado el siguiente diccionario de atributos
+(en formato JSON):
+\begin{verbatim}
+  {
+    descripcion: "Poner una piedra en la casilla actual.",
+    esAtomico: "SI"
+  }
+\end{verbatim}
+y la funci\'on \texttt{f} tiene asociado el siguiente diccionario de atributos:
+\begin{verbatim}
+  {
+    esAtomico: "NO"
+  }
+\end{verbatim}
+El int\'erprete no otorga ning\'un significado ni funcionalidad especial a los atributos.
+Son un mecanismo abierto cuya finalidad es dependiente de la implementaci\'on.
+
+\subsubsection{Pragma \texttt{LANGUAGE}}
+
+Establece opciones del lenguaje.
+El objetivo de esta directiva es habilitar extensiones y funcionalidades experimentales.
+La etapa de an\'alisis sint\'actico no se ve afectada por la directiva \texttt{LANGUAGE}.
+La directiva \texttt{LANGUAGE} puede potencialmente
+afectar las etapas de an\'alisis est\'atico ({\em linter}),
+compilaci\'on y el comportamiento en tiempo de ejecuci\'on.
+
+La sintaxis de la directiva es:
+\begin{itemize}
+\item \str{/*@LANGUAGE@nombre-de-la-opcion@*/} ---
+      habilita la opci\'on indicada.
+\end{itemize}
+
+Por el momento hay una \'unica directiva \texttt{LANGUAGE} implementada:
+\begin{itemize}
+\item \str{/*@LANGUAGE@DestructuringForeach@*/} ---
+      habilita la posibilidad de usar patrones complejos
+      como \'indice del \texttt{foreach}
+      (en lugar de permitir solamente variables).
+\end{itemize}
 
 \subsection{Producciones de la gram\'atica}
 

--- a/doc/gobstones.tex
+++ b/doc/gobstones.tex
@@ -521,7 +521,7 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
       patrones tupla,
       patrones variable,
       o patrones comod\'in.
-\item El patr\'on de un \texttt{foreach} \NOPUEDE ser un evento. \TODO{TBI}
+\item El patr\'on de un \texttt{foreach} \NOPUEDE ser un evento.
 \end{itemize}
 
 {\bf Expresiones.}

--- a/doc/gobstones.tex
+++ b/doc/gobstones.tex
@@ -356,7 +356,7 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
 \item Alcance de los nombres locales:
   \begin{itemize}
   \item Par\'ametros de procedimientos y funciones --- locales a todo el cuerpo del procedimiento o funci\'on.
-  \item Par\'ametros de constructores en un \texttt{switch} --- locales al bloque a la derecha de la correspondiente flecha \texttt{->}.
+  \item Variables ligadas en los patrones de un \texttt{switch} --- locales al bloque a la derecha de la correspondiente flecha \texttt{->}.
   \item \'Indices --- locales al cuerpo del \texttt{foreach}.
   \item Variables --- locales a todo el cuerpo del procedimiento o funci\'on.
   \end{itemize}
@@ -377,28 +377,29 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
 
 {\bf Pattern matching.}
 \begin{itemize}
-\item Hay cinco tipos de patrones:
-  \begin{itemize}
+\item Hay seis tipos de patrones:
+  \begin{enumerate}
   \item Patr\'on comod\'in (\texttt{\_}).
+  \item Patr\'on variable (identificador ligado localmente).
   \item Patr\'on num\'erico (un n\'umero $n$, que puede ser positivo, negativo o cero).
-  \item Patr\'on constructor (\texttt{C} o alternativamente \texttt{C(x$_1$, ..., x$_n$)}).
+  \item Patr\'on estructura (\texttt{C} o alternativamente \texttt{C(x$_1$, ..., x$_n$)}).
   \item Patr\'on tupla (\texttt{(x$_1$, ..., x$_n$)}).
   \item Patr\'on timeout (\texttt{TIMEOUT($n$)}).
-  \end{itemize}
-\item En un patr\'on constructor, el nombre del constructor en cuesti\'on \DEBE ser un constructor existente de
+  \end{enumerate}
+\item En un patr\'on estructura, el nombre del constructor en cuesti\'on \DEBE ser un constructor existente de
       alg\'un tipo.
-\item En un patr\'on constructor, el constructor \PUEDE tener $0$ par\'ametros, independientemente del n\'umero
+\item En un patr\'on estructura, el constructor \PUEDE tener $0$ par\'ametros, independientemente del n\'umero
       de campos que tenga el constructor correspondiente.
-\item Si un patr\'on constructor tiene $1$ o m\'as par\'ametros, el n\'umero \DEBE coincidir con el n\'umero
+\item Si un patr\'on estructura tiene $1$ o m\'as par\'ametros, el n\'umero \DEBE coincidir con el n\'umero
       de campos del constructor correspondiente.
-\item En una secuencia de ramas los patrones constructor \PUEDEN aparecer en cualquier orden, sin respetar necesariamente el orden en que est\'an declarados.
-\item Una secuencia de ramas \NOPUEDE tener dos patrones num\'ericos con el mismo valor num\'erico.    %TODO
-\item Una secuencia de ramas \NOPUEDE tener dos patrones constructor asociados al mismo constructor.
+\item En una secuencia de ramas los patrones estructura \PUEDEN aparecer en cualquier orden, sin respetar necesariamente el orden en que est\'an declarados.
+\item Una secuencia de ramas \NOPUEDE tener dos patrones num\'ericos con el mismo valor num\'erico.
+\item Una secuencia de ramas \NOPUEDE tener dos patrones estructura asociados al mismo constructor.
 \item Una secuencia de ramas \NOPUEDE tener dos patrones tupla con la misma longitud.
 \item Una secuencia de ramas \NOPUEDE tener dos patrones timeout.
-\item Una secuencia de ramas \PUEDE tener o no tener un patr\'on comod\'in.
-\item Si una secuencia de ramas tiene un patr\'on comod\'in, el patr\'on comod\'in \DEBE estar en la \'ultima rama.
-\item Una secuencia de ramas \NOPUEDE tener un patr\'on comod\'in en ninguna otra rama que no sea la \'ultima.
+\item Una secuencia de ramas \PUEDE tener o no tener un patr\'on comod\'in. (No es obligatorio como \'ultima rama).
+\item Si una secuencia de ramas tiene un patr\'on comod\'in o un patr\'on variable, dicho patr\'on \DEBE estar en la \'ultima rama.
+\item Una secuencia de ramas \NOPUEDE tener un patr\'on comod\'in o un patr\'on variable en ninguna otra rama que no sea la \'ultima.
 \item Un patr\'on comod\'in \PUEDE ser inalcanzable.
       Es decir, un patr\'on comod\'in puede estar presente incluso si la secuencia de ramas
       cubre todas las alternativas de constructores posibles.
@@ -406,28 +407,29 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
       Son patrones compatibles:
       \begin{itemize}
       \item Dos patrones num\'ericos.
-      \item Dos patrones constructor cuyos constructores pertenecen al mismo tipo.
+      \item Dos patrones estructura cuyos constructores pertenecen al mismo tipo.
       \item Un patr\'on timeout con cualquier otro constructor del tipo \texttt{\_EVENT}
             (que corresponde a los eventos que pueden darse en un programa interactivo).
-      \item El patr\'on comod\'in con cualquier otro patr\'on.
+      \item Un patr\'on comod\'in con cualquier otro patr\'on.
+      \item Un patr\'on variable con cualquier otro patr\'on.
       \end{itemize}
       Dos tipos son incompatibles en cualquier otro caso. En particular, son patrones incompatibles:
       \begin{itemize}
-      \item Un patr\'on num\'erico y un patr\'on constructor.
+      \item Un patr\'on num\'erico y un patr\'on estructura.
       \item Un patr\'on num\'erico y un patr\'on tupla.
-      \item Dos patrones constructor cuyos constructores pertenecen a distintos tipos.
+      \item Dos patrones estructura cuyos constructores pertenecen a distintos tipos.
       \item Dos patrones tupla con distinto n\'umero de componentes.
-      \item Un patr\'on constructor y un patr\'on tupla.
+      \item Un patr\'on estructura y un patr\'on tupla.
       \end{itemize}
 \item Los patrones de las ramas del \texttt{interactive program}
       \DEBEN ser eventos, es decir:
       patrones timeout,
-      patrones constructor del tipo \texttt{\_EVENT},
+      patrones estructura del tipo \texttt{\_EVENT},
       o patrones comod\'in.
-\item Los de las ramas de los \texttt{switch} \NOPUEDEN ser eventos, es decir:
+\item Los patrones de las ramas de los \texttt{switch} \NOPUEDEN ser eventos, es decir:
       pueden ser
       patrones num\'ericos,
-      patrones constructor de tipos que no sean \texttt{\_EVENT},
+      patrones estructura de tipos que no sean \texttt{\_EVENT},
       patrones tupla,
       o patrones comod\'in.
 \end{itemize}
@@ -436,17 +438,17 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
 \begin{itemize}
 \item Los usos de par\'ametros, \'indices y variables (\ast{ExprVariable}) \PUEDEN no corresponder a par\'ametros, \'indices o variables definidas.
       La restricci\'on de que las variables se pueden usar solamente despu\'es de que se les haya dado un valor es una restricci\'on din\'amica.
-\item Cuando se construye una instancia de un tipo (registro o variante) con un constructor (\ast{ExprConstructor}),
+\item Cuando se construye una instancia de un tipo (registro o variante) con un constructor (\ast{ExprStructure}),
       el nombre del constructor \DEBE ser el nombre de un constructor existente.
-\item Cuando se construye o se actualiza una instancia con un constructor (\ast{ExprConstructor}, \ast{ExprConstructorUpdate}),
+\item Cuando se construye o se actualiza una instancia con un constructor (\ast{ExprStructure}, \ast{ExprStructureUpdate}),
       \NOPUEDE haber nombres de campos repetidos en la lista de {\em bindings}.
-\item Cuando se construye o se actualiza una instancia con un constructor (\ast{ExprConstructor}, \ast{ExprConstructorUpdate}),
+\item Cuando se construye o se actualiza una instancia con un constructor (\ast{ExprStructure}, \ast{ExprStructureUpdate}),
       los nombres de los campos que aparecen en la lista de {\em bindings}
       \DEBEN ser nombres de campos v\'alidos para dicho constructor. (Correctitud).
-\item Cuando se construye una instancia con un constructor (\ast{ExprConstructor}),
+\item Cuando se construye una instancia con un constructor (\ast{ExprStructure}),
       los nombres de los campos que aparecen en la lista de {\em bindings}
       \DEBEN cubrir todos los posibles nombres de campos v\'alidos para dicho constructor. (Completitud).
-\item Cuando se construye o se actualiza una instancia con un constructor (\ast{ExprConstructor}, \ast{ExprConstructorUpdate}),
+\item Cuando se construye o se actualiza una instancia con un constructor (\ast{ExprStructure}, \ast{ExprStructureUpdate}),
       el constructor \NOPUEDE ser un constructor del tipo \texttt{\_EVENT} (esto t\'ecnicamente depende
       del entorno global en el que se eval\'ue el programa, pero t\'ipicamente
       los eventos son las teclas como \texttt{K\_ENTER}, etc.).

--- a/src/ast.js
+++ b/src/ast.js
@@ -299,9 +299,9 @@ export class ASTStmtForeach extends ASTNode {
     super(N_StmtForeach, [pattern, range, body]);
   }
 
-  // TODO: Remove
+  // TODO: BORRAR
   get index() {
-    return this._children[0].variableName;
+    return this.pattern.variableName;
   }
 
   get pattern() {

--- a/src/ast.js
+++ b/src/ast.js
@@ -21,6 +21,7 @@ export const N_StmtAssignTuple = Symbol.for('N_StmtAssignTuple');
 export const N_StmtProcedureCall = Symbol.for('N_StmtProcedureCall');
 /* Patterns */
 export const N_PatternWildcard = Symbol.for('N_PatternWildcard');
+export const N_PatternVariable = Symbol.for('N_PatternVariable');
 export const N_PatternNumber = Symbol.for('N_PatternNumber');
 export const N_PatternStructure = Symbol.for('N_PatternStructure');
 export const N_PatternTuple = Symbol.for('N_PatternTuple');
@@ -300,6 +301,7 @@ export class ASTStmtForeach extends ASTNode {
 
   get index() {
     return this._children[0];
+    //return this._children[0].variableName();
   }
 
   get range() {
@@ -402,8 +404,22 @@ export class ASTPatternWildcard extends ASTNode {
     super(N_PatternWildcard, []);
   }
 
-  get parameters() {
+  get boundVariables() {
     return [];
+  }
+}
+
+export class ASTPatternVariable extends ASTNode {
+  constructor(variableName) {
+    super(N_PatternVariable, [variableName]);
+  }
+
+  get variableName() {
+    return this._children[0];
+  }
+
+  get boundVariables() {
+    return [this._children[0]];
   }
 }
 
@@ -416,7 +432,7 @@ export class ASTPatternNumber extends ASTNode {
     return this._children[0];
   }
 
-  get parameters() {
+  get boundVariables() {
     return [];
   }
 }
@@ -430,7 +446,7 @@ export class ASTPatternStructure extends ASTNode {
     return this._children[0];
   }
 
-  get parameters() {
+  get boundVariables() {
     return this._children[1];
   }
 }
@@ -440,7 +456,7 @@ export class ASTPatternTuple extends ASTNode {
     super(N_PatternTuple, parameters);
   }
 
-  get parameters() {
+  get boundVariables() {
     return this._children;
   }
 }
@@ -450,7 +466,7 @@ export class ASTPatternTimeout extends ASTNode {
     super(N_PatternTimeout, [timeout]);
   }
 
-  get parameters() {
+  get boundVariables() {
     return [];
   }
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -295,13 +295,17 @@ export class ASTStmtRepeat extends ASTNode {
 }
 
 export class ASTStmtForeach extends ASTNode {
-  constructor(index, range, body) {
-    super(N_StmtForeach, [index, range, body]);
+  constructor(pattern, range, body) {
+    super(N_StmtForeach, [pattern, range, body]);
   }
 
+  // TODO: Remove
   get index() {
+    return this._children[0].variableName;
+  }
+
+  get pattern() {
     return this._children[0];
-    //return this._children[0].variableName();
   }
 
   get range() {

--- a/src/ast.js
+++ b/src/ast.js
@@ -299,11 +299,6 @@ export class ASTStmtForeach extends ASTNode {
     super(N_StmtForeach, [pattern, range, body]);
   }
 
-  // TODO: BORRAR
-  get index() {
-    return this.pattern.variableName;
-  }
-
   get pattern() {
     return this._children[0];
   }

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -427,6 +427,12 @@ export const LOCALE_ES = {
   'errmsg:wildcard-pattern-should-be-last':
     'El comodín "_" tiene que ser la última rama del switch.',
 
+  'errmsg:variable-pattern-should-be-last':
+    function (name) {
+      return 'El patrón variable "' + name +
+             '" tiene que ser la última rama del switch.';
+    },
+
   'errmsg:numeric-pattern-repeats-number':
     function (number) {
       return 'Hay dos ramas distintas para el número "' + number + '".';

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -499,6 +499,9 @@ export const LOCALE_ES = {
   'errmsg:forbidden-extension-destructuring-foreach':
     'El índice de la repetición indexada debe ser una variable.',
 
+  'errmsg:patterns-in-foreach-must-not-be-events':
+    'El patrón de un foreach no puede ser un evento.',
+
   /* Runtime errors (virtual machine) */
   'errmsg:undefined-variable':
     function (variableName) {

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -685,6 +685,7 @@ export const LOCALE_ES = {
 
   'PRIM:BOOM': 'BOOM',
   'PRIM:boom': 'boom',
+  'PRIM:ellipsis': 'El programa todavía no está completo.',
 
   'PRIM:PutStone': 'Poner',
   'PRIM:RemoveStone': 'Sacar',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -497,7 +497,7 @@ export const LOCALE_ES = {
     },
 
   'errmsg:forbidden-extension-destructuring-foreach':
-    'El índice de la repetición indexada debe ser una variable.',
+    'El índice de la repetición indexada debe ser un identificador.',
 
   'errmsg:patterns-in-foreach-must-not-be-events':
     'El patrón de un foreach no puede ser un evento.',
@@ -627,6 +627,9 @@ export const LOCALE_ES = {
 
   'errmsg:switch-does-not-match':
     'El valor analizado no coincide con ninguna de las ramas del switch.',
+
+  'errmsg:foreach-pattern-does-not-match':
+    'El elemento no coincide con el patrón esperado por el foreach.',
 
   'errmsg:cannot-divide-by-zero':
     'No se puede dividir por cero.',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -244,6 +244,11 @@ export const LOCALE_ES = {
            + 'pero no había ' + openingDelimiterName(delimiter) + '.';
     },
 
+  'errmsg:unknown-language-option':
+    function (option) {
+      return 'Opción desconocida. "' + option + '".';
+    },
+
   /* Parser */
   'errmsg:empty-source':
     'El programa está vacío.',
@@ -490,6 +495,9 @@ export const LOCALE_ES = {
            + 'en un programa interactivo (el usuario no puede construir '
            + 'instancias).';
     },
+
+  'errmsg:forbidden-extension-destructuring-foreach':
+    'El índice de la repetición indexada debe ser una variable.',
 
   /* Runtime errors (virtual machine) */
   'errmsg:undefined-variable':

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -470,7 +470,7 @@ export class Lexer {
       let key = pragma[1];
       let value = pragma.slice(2, pragma.length).join('@');
       this.setAttribute(key, value);
-    } else if (pragma[0] === 'LANGUAGE' && pragma.length == 2) {
+    } else if (pragma[0] === 'LANGUAGE' && pragma.length === 2) {
       let languageOption = pragma[1];
       this.addLanguageOption(languageOption);
     } else {
@@ -553,7 +553,7 @@ export class Lexer {
   }
 
   addLanguageOption(option) {
-    if (LANGUAGE_OPTIONS.indexOf(option) != -1) {
+    if (LANGUAGE_OPTIONS.indexOf(option) !== -1) {
       this._languageOptions.push(option);
     } else {
       fail(this._reader, this._reader, 'unknown-language-option', [option]);

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -13,7 +13,7 @@ import {
   T_TIMEOUT,
   /* Symbols */
   T_LPAREN, T_RPAREN, T_LBRACE, T_RBRACE, T_LBRACK, T_RBRACK, T_COMMA,
-  T_SEMICOLON, T_RANGE, T_GETS, T_PIPE, T_ARROW, T_ASSIGN,
+  T_SEMICOLON, T_ELLIPSIS, T_RANGE, T_GETS, T_PIPE, T_ARROW, T_ASSIGN,
   T_EQ, T_NE, T_LE, T_GE, T_LT, T_GT, T_AND, T_OR, T_CONCAT, T_PLUS,
   T_MINUS, T_TIMES, T_POW
 } from './token';
@@ -101,10 +101,11 @@ const SYMBOLS = [
   [')', T_RPAREN],
   ['{', T_LBRACE],
   ['}', T_RBRACE],
-  ['[', T_LBRACK],    // For lists and ranges
+  ['[', T_LBRACK],     // For lists and ranges
   [']', T_RBRACK],
   [',', T_COMMA],
   [';', T_SEMICOLON],
+  ['...', T_ELLIPSIS], // For intentionally incomplete programs
   /* Range operator */
   ['..', T_RANGE],
   /* Assignment */
@@ -113,10 +114,10 @@ const SYMBOLS = [
   ['&&', T_AND],
   ['||', T_OR],
   /* Fields */
-  ['<-', T_GETS],     // Field initializer, e.g. Coord(x <- 1, y <- 2)
-  ['|', T_PIPE],      // Field update, e.g. Coord(c | x <- 2)
+  ['<-', T_GETS],      // Field initializer, e.g. Coord(x <- 1, y <- 2)
+  ['|', T_PIPE],       // Field update, e.g. Coord(c | x <- 2)
   /* Pattern matching */
-  ['->', T_ARROW],    // For the branches of a switch
+  ['->', T_ARROW],     // For the branches of a switch
   /* Relational operators */
   ['==', T_EQ],
   ['/=', T_NE],

--- a/src/linter.js
+++ b/src/linter.js
@@ -404,13 +404,13 @@ export class Linter {
     let i = 0;
     const n = branches.length;
     for (let branch of branches) {
-      if (branch.pattern.tag === N_PatternWildcard  && i !== n - 1) {
+      if (branch.pattern.tag === N_PatternWildcard && i !== n - 1) {
         this._lintCheck(
           branch.pattern.startPos, branch.pattern.endPos,
           'wildcard-pattern-should-be-last', []
         );
       }
-      if (branch.pattern.tag === N_PatternVariable  && i !== n - 1) {
+      if (branch.pattern.tag === N_PatternVariable && i !== n - 1) {
         this._lintCheck(
           branch.pattern.startPos, branch.pattern.endPos,
           'variable-pattern-should-be-last', [branch.pattern.variableName.value]

--- a/src/parser.js
+++ b/src/parser.js
@@ -433,7 +433,7 @@ export class Parser {
     let startPos = this._currentToken.startPos;
     this._match(T_ELLIPSIS);
     let result = new ASTStmtProcedureCall(
-      new Token(T_UPPERID, i18n('PRIM:BOOM'), startPos, startPos), [ 
+      new Token(T_UPPERID, i18n('PRIM:BOOM'), startPos, startPos), [
         new ASTExprConstantString(
           new Token(T_STRING, i18n('errmsg:ellipsis'))
         )
@@ -882,7 +882,7 @@ export class Parser {
     let startPos = this._currentToken.startPos;
     this._match(T_ELLIPSIS);
     let result = new ASTExprFunctionCall(
-      new Token(T_LOWERID, i18n('PRIM:boom'), startPos, startPos), [ 
+      new Token(T_LOWERID, i18n('PRIM:boom'), startPos, startPos), [
         new ASTExprConstantString(
           new Token(T_STRING, i18n('errmsg:ellipsis'))
         )

--- a/src/parser.js
+++ b/src/parser.js
@@ -182,6 +182,12 @@ export class Parser {
     return new ASTMain(definitions);
   }
 
+  /* Return the list of all language options collected by the tokenizer.
+   * Language options are set by the LANGUAGE pragma. */
+  getLanguageOptions() {
+    return this._lexer.getLanguageOptions();
+  }
+
   /** Definitions **/
 
   _parseDefinition() {

--- a/src/parser.js
+++ b/src/parser.js
@@ -482,12 +482,11 @@ export class Parser {
   _parseStmtForeach() {
     let startPos = this._currentToken.startPos;
     this._match(T_FOREACH);
-    //let index = this._parsePattern(); // TODO
-    let index = this._parseLowerid();
+    let pattern = this._parsePattern();
     this._match(T_IN);
     let range = this._parseExpression();
     let body = this._parseStmtBlock();
-    let result = new ASTStmtForeach(index, range, body);
+    let result = new ASTStmtForeach(pattern, range, body);
     result.startPos = startPos;
     result.endPos = body.endPos;
     return result;

--- a/src/parser.js
+++ b/src/parser.js
@@ -39,6 +39,7 @@ import {
   ASTStmtProcedureCall,
   /* Patterns */
   ASTPatternWildcard,
+  ASTPatternVariable,
   ASTPatternNumber,
   ASTPatternStructure,
   ASTPatternTuple,
@@ -481,6 +482,7 @@ export class Parser {
   _parseStmtForeach() {
     let startPos = this._currentToken.startPos;
     this._match(T_FOREACH);
+    //let index = this._parsePattern(); // TODO
     let index = this._parseLowerid();
     this._match(T_IN);
     let range = this._parseExpression();
@@ -597,6 +599,8 @@ export class Parser {
     switch (this._currentToken.tag) {
       case T_UNDERSCORE:
         return this._parsePatternWildcard();
+      case T_LOWERID:
+        return this._parsePatternVariable();
       case T_NUM: case T_MINUS:
         return this._parsePatternNumber();
       case T_UPPERID:
@@ -623,6 +627,15 @@ export class Parser {
     let endPos = startPos;
     result.startPos = startPos;
     result.endPos = endPos;
+    return result;
+  }
+
+  _parsePatternVariable() {
+    let startPos = this._currentToken.startPos;
+    let id = this._parseLowerid();
+    let result = new ASTPatternVariable(id);
+    result.startPos = startPos;
+    result.endPos = id.endPos;
     return result;
   }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -13,7 +13,7 @@ import {
   T_TIMEOUT,
   /* Symbols */
   T_LPAREN, T_RPAREN, T_LBRACE, T_RBRACE, T_LBRACK, T_RBRACK, T_COMMA,
-  T_SEMICOLON, T_RANGE, T_GETS, T_PIPE, T_ARROW, T_ASSIGN,
+  T_SEMICOLON, T_ELLIPSIS, T_RANGE, T_GETS, T_PIPE, T_ARROW, T_ASSIGN,
   T_EQ, T_NE, T_LE, T_GE, T_LT, T_GT, T_AND, T_OR, T_CONCAT, T_PLUS,
   T_MINUS, T_TIMES, T_POW
 } from './token';
@@ -368,6 +368,8 @@ export class Parser {
   /* Statement (not followed by semicolon) */
   _parsePureStatement() {
     switch (this._currentToken.tag) {
+      case T_ELLIPSIS:
+        return this._parseStmtEllipsis();
       case T_RETURN:
         return this._parseStmtReturn();
       case T_IF:
@@ -424,6 +426,21 @@ export class Parser {
     let result = new ASTStmtBlock(statements);
     result.startPos = startPos;
     result.endPos = endPos;
+    return result;
+  }
+
+  _parseStmtEllipsis() {
+    let startPos = this._currentToken.startPos;
+    this._match(T_ELLIPSIS);
+    let result = new ASTStmtProcedureCall(
+      new Token(T_UPPERID, i18n('PRIM:BOOM'), startPos, startPos), [ 
+        new ASTExprConstantString(
+          new Token(T_STRING, i18n('errmsg:ellipsis'))
+        )
+      ]
+    );
+    result.startPos = startPos;
+    result.endPos = this._currentToken.startPos;
     return result;
   }
 
@@ -834,6 +851,8 @@ export class Parser {
    * I.e. all the operators must be surrounded by parentheses */
   _parseExprAtom() {
     switch (this._currentToken.tag) {
+      case T_ELLIPSIS:
+        return this._parseExprEllipsis();
       case T_LOWERID:
         return this._parseExprVariableOrFunctionCall();
       case T_NUM:
@@ -857,6 +876,21 @@ export class Parser {
           ]
         );
     }
+  }
+
+  _parseExprEllipsis() {
+    let startPos = this._currentToken.startPos;
+    this._match(T_ELLIPSIS);
+    let result = new ASTExprFunctionCall(
+      new Token(T_LOWERID, i18n('PRIM:boom'), startPos, startPos), [ 
+        new ASTExprConstantString(
+          new Token(T_STRING, i18n('errmsg:ellipsis'))
+        )
+      ]
+    );
+    result.startPos = startPos;
+    result.endPos = this._currentToken.startPos;
+    return result;
   }
 
   _parseExprVariableOrFunctionCall() {

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,5 +1,4 @@
 
-import { GbsSyntaxError } from './exceptions';
 import { Parser } from './parser';
 import { Linter } from './linter';
 import { SymbolTable } from './symtable';
@@ -138,7 +137,7 @@ export class Runner {
 
   /* Evaluate language options set by the LANGUAGE pragma */
   _setLanguageOption(option) {
-    if (option == 'DestructuringForeach') {
+    if (option === 'DestructuringForeach') {
       this.enableLintCheck('forbidden-extension-destructuring-foreach', false);
     } else {
       throw Error('Unknown language option: ' + option);

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,4 +1,5 @@
 
+import { GbsSyntaxError } from './exceptions';
 import { Parser } from './parser';
 import { Linter } from './linter';
 import { SymbolTable } from './symtable';
@@ -68,7 +69,12 @@ export class Runner {
   }
 
   parse(input) {
-    this._ast = new Parser(input).parse();
+    let parser = new Parser(input);
+    this._ast = parser.parse();
+
+    for (let option of parser.getLanguageOptions()) {
+      this._setLanguageOption(option);
+    }
   }
 
   enableLintCheck(linterCheckId, enabled) {
@@ -128,6 +134,15 @@ export class Runner {
 
   get globalState() {
     return this._vm.globalState();
+  }
+
+  /* Evaluate language options set by the LANGUAGE pragma */
+  _setLanguageOption(option) {
+    if (option == 'DestructuringForeach') {
+      this.enableLintCheck('forbidden-extension-destructuring-foreach', false);
+    } else {
+      throw Error('Unknown language option: ' + option);
+    }
   }
 
   /* Dynamic stack of regions */

--- a/src/token.js
+++ b/src/token.js
@@ -47,6 +47,7 @@ export const T_LBRACK = Symbol.for('T_LBRACK');
 export const T_RBRACK = Symbol.for('T_RBRACK');
 export const T_COMMA = Symbol.for('T_COMMA');
 export const T_SEMICOLON = Symbol.for('T_SEMICOLON');
+export const T_ELLIPSIS = Symbol.for('T_ELLIPSIS');
 export const T_RANGE = Symbol.for('T_RANGE');
 export const T_GETS = Symbol.for('T_GETS');
 export const T_PIPE = Symbol.for('T_PIPE');

--- a/test/01.lexer.spec.js
+++ b/test/01.lexer.spec.js
@@ -12,7 +12,7 @@ import {
   T_TIMEOUT,
   /* Symbols */
   T_LPAREN, T_RPAREN, T_LBRACE, T_RBRACE, T_LBRACK, T_RBRACK, T_COMMA,
-  T_SEMICOLON, T_RANGE, T_GETS, T_PIPE, T_ARROW, T_ASSIGN,
+  T_SEMICOLON, T_ELLIPSIS, T_RANGE, T_GETS, T_PIPE, T_ARROW, T_ASSIGN,
   T_EQ, T_NE, T_LE, T_GE, T_LT, T_GT, T_AND, T_OR, T_CONCAT, T_PLUS,
   T_MINUS, T_TIMES, T_POW
 } from '../src/token';
@@ -187,6 +187,7 @@ describe('Lexer', () => {
         ']',
         ',',
         ';',
+        '...',
         '..',
         '<-',
         '|',
@@ -216,6 +217,7 @@ describe('Lexer', () => {
         T_RBRACK,
         T_COMMA,
         T_SEMICOLON,
+        T_ELLIPSIS,
         T_RANGE,
         T_GETS,
         T_PIPE,

--- a/test/02.parser.definitions.spec.js
+++ b/test/02.parser.definitions.spec.js
@@ -753,4 +753,33 @@ describe('Parser: definitions', () => {
 
   });
 
+  describe('LANGUAGE pragma', () => {
+
+    it('Recognize LANGUAGE option DestructuringForeach', () => {
+      let parser = new Parser([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '}'
+      ]);
+      parser.parse();
+      expect(parser.getLanguageOptions()).deep.equals([
+        'DestructuringForeach'
+      ]);
+    });
+
+    it('Fail on unknown LANGUAGE option', () => {
+      expect(() => 
+          new Parser([
+            '/*@LANGUAGE@foobar@*/',
+            'program {',
+            '}'
+          ]).parse()
+      ).throws(
+        i18n('errmsg:unknown-language-option')('foobar')
+      );
+    });
+
+  });
+
 });
+

--- a/test/03.parser.statements.spec.js
+++ b/test/03.parser.statements.spec.js
@@ -1552,4 +1552,25 @@ describe('Parser: statements', () => {
 
   });
 
+  describe('Ellipsis statement', () => {
+
+    it('Parse ellipsis statement and macroexpand to BOOM', () => {
+      let parser = new Parser(
+                     'program {\n' +
+                     '  ...\n' +
+                     '}\n'
+                   );
+      expectAST(parser.parse(), [
+        new ASTDefProgram(
+          new ASTStmtBlock([
+            new ASTStmtProcedureCall(tok(T_UPPERID, i18n('PRIM:BOOM')), [
+              new ASTExprConstantString(tok(T_STRING, i18n('errmsg:ellipsis')))
+            ])
+          ])
+        )
+      ]);
+    });
+
+  });
+
 });

--- a/test/03.parser.statements.spec.js
+++ b/test/03.parser.statements.spec.js
@@ -24,6 +24,7 @@ import {
   ASTStmtProcedureCall,
   /* Patterns */
   ASTPatternWildcard,
+  ASTPatternVariable,
   ASTPatternNumber,
   ASTPatternStructure,
   ASTPatternTuple,
@@ -832,6 +833,39 @@ describe('Parser: statements', () => {
       ]);
     });
 
+    it('Accept variable pattern', () => {
+      let parser = new Parser(
+                     'program {' +
+                     '  switch (foo) {' +
+                     '    x -> {' +
+                     '      if (bar) {}' +
+                     '    }' +
+                     '  }' +
+                     '}'
+                   );
+      expectAST(parser.parse(), [
+        new ASTDefProgram(
+          new ASTStmtBlock([
+            new ASTStmtSwitch(
+              new ASTExprVariable(tok(T_LOWERID, 'foo')),
+              [
+                new ASTSwitchBranch(
+                  new ASTPatternVariable(tok(T_LOWERID, 'x')),
+                  new ASTStmtBlock([
+                    new ASTStmtIf(
+                      new ASTExprVariable(tok(T_LOWERID, 'bar')),
+                      new ASTStmtBlock([]),
+                      null
+                    )
+                  ])
+                )
+              ]
+            )
+          ])
+        )
+      ]);
+    });
+
     it('Accept wildcard pattern (_)', () => {
       let parser = new Parser(
                      'program {' +
@@ -1128,18 +1162,18 @@ describe('Parser: statements', () => {
       );
     });
 
-    it('Reject malformed pattern (single variable)', () => {
+    it('Reject malformed pattern (function)', () => {
       let parser = new Parser(
                      'program {' +
                      '  switch (foo) {' +
-                     '    x -> {}' +
+                     '    x(y) -> {}' +
                      '  }' +
                      '}'
                    );
       expect(() => parser.parse()).throws(
         i18n('errmsg:expected-but-found')(
-          i18n('pattern'),
-          i18n('T_LOWERID')
+          i18n('T_ARROW'),
+          i18n('T_LPAREN')
         )
       );
     });

--- a/test/04.parser.expressions.spec.js
+++ b/test/04.parser.expressions.spec.js
@@ -2269,4 +2269,32 @@ describe('Parser: expressions', () => {
 
   });
 
+  describe('Ellipsis expression', () => {
+
+    it('Parse ellipsis expression and macroexpand to boom', () => {
+      let parser = new Parser(
+                     'program {\n' +
+                     '  x := ...\n' +
+                     '}\n'
+                   );
+      expectAST(parser.parse(), [
+        new ASTDefProgram(
+          new ASTStmtBlock([
+            new ASTStmtAssignVariable(
+              tok(T_LOWERID, 'x'),
+              new ASTExprFunctionCall(
+                tok(T_LOWERID, i18n('PRIM:boom')), [
+                  new ASTExprConstantString(
+                    tok(T_STRING, i18n('errmsg:ellipsis'))
+                  )
+                ]
+              )
+            )
+          ])
+        )
+      ]);
+    });
+
+  });
+
 });

--- a/test/04.parser.expressions.spec.js
+++ b/test/04.parser.expressions.spec.js
@@ -24,6 +24,7 @@ import {
   ASTStmtProcedureCall,
   /* Patterns */
   ASTPatternWildcard,
+  ASTPatternVariable,
   ASTPatternStructure,
   ASTPatternTuple,
   ASTPatternTimeout,
@@ -187,7 +188,7 @@ describe('Parser: expressions', () => {
               new ASTStmtBlock([]),
             ),
             new ASTStmtForeach(
-              tok(T_LOWERID, 'i'),
+              new ASTPatternVariable(tok(T_LOWERID, 'i')),
               new ASTExprFunctionCall(tok(T_LOWERID, 'f3'), []),
               new ASTStmtBlock([]),
             ),

--- a/test/05.linter.spec.js
+++ b/test/05.linter.spec.js
@@ -16,6 +16,18 @@ function lint(code) {
   return new Linter(new SymbolTable()).lint(new Parser(code).parse());
 }
 
+function lintDisableDestructuringForeach(code) {
+  let l = new Linter(new SymbolTable());
+  l.enableCheck('forbidden-extension-destructuring-foreach', true);
+  return l.lint(new Parser(code).parse());
+}
+
+function lintEnableDestructuringForeach(code) {
+  let l = new Linter(new SymbolTable());
+  l.enableCheck('forbidden-extension-destructuring-foreach', false);
+  return l.lint(new Parser(code).parse());
+}
+
 function tok(tag, value) {
   return new Token(tag, value, UnknownPosition, UnknownPosition);
 }
@@ -683,6 +695,66 @@ describe('Linter', () => {
           i18n('<position>')('(?)', 4, 10),
         )
       );
+    });
+
+  });
+
+  describe('Foreach statement', () => {
+
+    it('Always accept foreach with variable index', () => {
+      let code = [
+        'program {',
+        '  foreach i in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(
+        lintDisableDestructuringForeach(code).program !== null
+      ).equals(true);
+    });
+
+    it('DestructuringForeach disabled -- Reject wildcard index', () => {
+      let code = [
+        'program {',
+        '  foreach _ in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(() => lintDisableDestructuringForeach(code)).throws(
+        i18n('errmsg:forbidden-extension-destructuring-foreach')
+      );
+    });
+
+    it('DestructuringForeach enabled -- Accept wildcard index', () => {
+      let code = [
+        'program {',
+        '  foreach _ in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(lintEnableDestructuringForeach(code) === null).equals(false);
+    });
+
+    it('DestructuringForeach disabled -- Reject tuple index', () => {
+      let code = [
+        'program {',
+        '  foreach (x,y) in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(() => lintDisableDestructuringForeach(code)).throws(
+        i18n('errmsg:forbidden-extension-destructuring-foreach')
+      );
+    });
+
+    it('DestructuringForeach enabled -- Accept tuple index', () => {
+      let code = [
+        'program {',
+        '  foreach (x,y) in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(lintEnableDestructuringForeach(code) === null).equals(false);
     });
 
   });

--- a/test/05.linter.spec.js
+++ b/test/05.linter.spec.js
@@ -757,6 +757,41 @@ describe('Linter', () => {
       expect(lintEnableDestructuringForeach(code) === null).equals(false);
     });
 
+    it('Always reject events as indices', () => {
+      let code = [
+        'program {',
+        '  foreach ' + i18n('CONS:TIMEOUT') + '(1) in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(() => lintEnableDestructuringForeach(code)).throws(
+        i18n('errmsg:patterns-in-foreach-must-not-be-events')
+      );
+    });
+
+    it('Accept structure pattern', () => {
+      let code = [
+        'type A is record { field x field y }',
+        'program {',
+        '  foreach A(a, b) in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(lintEnableDestructuringForeach(code) === null).equals(false);
+    });
+
+    it('Reject structure pattern with undefined constructor', () => {
+      let code = [
+        'program {',
+        '  foreach A(a, b) in [] {',
+        '  }',
+        '}',
+      ].join('\n');
+      expect(() => lintEnableDestructuringForeach(code)).throws(
+        i18n('errmsg:undeclared-constructor')('A')
+      );
+    });
+
   });
 
   describe('Procedure and function calls', () => {

--- a/test/07.compiler.spec.js
+++ b/test/07.compiler.spec.js
@@ -420,6 +420,25 @@ describe('Compiler', () => {
       expect(result).deep.equals(new ValueInteger(42));
     });
 
+    it('Switch: match variable', () => {
+      let result = new Runner().run([
+        'program {',
+        '  switch ((1,2,3)) {',
+        '    z -> { x := z }',
+        '  }',
+        '  y := x',
+        '  return (y)',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(
+        new ValueTuple([
+          new ValueInteger(1),
+          new ValueInteger(2),
+          new ValueInteger(3)
+        ])
+      );
+    });
+
     it('Switch: empty switch (no match)', () => {
       let result = () => new Runner().run([
         'program {',

--- a/test/07.compiler.spec.js
+++ b/test/07.compiler.spec.js
@@ -368,6 +368,205 @@ describe('Compiler', () => {
       );
     });
 
+    it('Foreach (destructuring): wildcard pattern', () => {
+      let result = new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '  x := 0',
+        '  foreach _ in [1, 2, 3] {',
+        '    x := 2 * x',
+        '    foreach _ in [4, 5] {',
+        '      x := x + 1',
+        '    }',
+        '  }',
+        '  return (x)',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(new ValueInteger(14));
+    });
+
+    it('Foreach (destructuring): numeric pattern', () => {
+      let result = new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '  x := 0',
+        '  foreach -12 in [2 * -6, -1 * 12, -6 - 6] {',
+        '    x := x + 1',
+        '  }',
+        '  return (x)',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(new ValueInteger(3));
+    });
+
+    it('Foreach (destructuring): numeric pattern -- mismatch', () => {
+      let result = () => new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '  x := 0',
+        '  foreach -12 in [12] {',
+        '    x := x + 1',
+        '  }',
+        '  return (x)',
+        '}',
+      ].join('\n'));
+      expect(result).throws(i18n('errmsg:foreach-pattern-does-not-match'));
+    });
+
+    it('Foreach (destructuring): tuple pattern', () => {
+      let result = new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '  lx := []',
+        '  ly := []',
+        '  foreach (x, y) in [(1, "a"), (2, "b"), (3, "c")] {',
+        '    lx := lx ++ [x]',
+        '    ly := ly ++ [y]',
+        '  }',
+        '  return (lx, ly)',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(
+        new ValueTuple([
+          new ValueList([
+            new ValueInteger(1),
+            new ValueInteger(2),
+            new ValueInteger(3)
+          ]),
+          new ValueList([
+            new ValueString("a"),
+            new ValueString("b"),
+            new ValueString("c")
+          ]),
+        ])
+      );
+    });
+
+    it('Foreach (destructuring): tuple pattern -- type mismatch', () => {
+      let result = () => new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '  foreach (x, y) in [()] {',
+        '  }',
+        '}',
+      ].join('\n'));
+      expect(result).throws(
+        i18n('errmsg:expected-value-of-type-but-got')(
+          new TypeTuple([new TypeAny(), new TypeAny()]),
+          new TypeTuple([])
+        )
+      );
+    });
+
+    it('Foreach (destructuring): structure pattern', () => {
+      let result = new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'type A is record {',
+        '  field ax',
+        '  field ay',
+        '}',
+        'program {',
+        '  lx := []',
+        '  ly := []',
+        '  foreach A(x, y) in [',
+        '      A(ax <- 1, ay <- "a"),',
+        '      A(ax <- 2, ay <- "b"),',
+        '      A(ax <- 3, ay <- "c")',
+        '  ] {',
+        '    lx := lx ++ [x]',
+        '    ly := ly ++ [y]',
+        '  }',
+        '  return (lx, ly)',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(
+        new ValueTuple([
+          new ValueList([
+            new ValueInteger(1),
+            new ValueInteger(2),
+            new ValueInteger(3)
+          ]),
+          new ValueList([
+            new ValueString("a"),
+            new ValueString("b"),
+            new ValueString("c")
+          ]),
+        ])
+      );
+    });
+
+    it('Foreach (destructuring): structure pattern --- variant', () => {
+      let result = new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'type A is variant {',
+        '  case B {',
+        '    field x',
+        '  }',
+        '  case C {',
+        '    field x',
+        '  }',
+        '}',
+        'program {',
+        '  y := 0',
+        '  foreach B(x) in [B(x <- 100), B(x <- 1)] {',
+        '    y := y + x',
+        '  }',
+        '  return (y)',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(new ValueInteger(101));
+    });
+
+    it('Foreach (destructuring): structure pattern --- no match', () => {
+      let result = () => new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'type A is variant {',
+        '  case B {',
+        '    field x',
+        '  }',
+        '  case C {',
+        '    field x',
+        '  }',
+        '}',
+        'program {',
+        '  y := 0',
+        '  foreach B(x) in [B(x <- 100), C(x <- 1)] {',
+        '    y := y + x',
+        '  }',
+        '  return (y)',
+        '}',
+      ].join('\n'));
+      expect(result).throws(i18n('errmsg:foreach-pattern-does-not-match'));
+    });
+
+    it('Foreach (destructuring): unbind variables -- empty list', () => {
+      let result = new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '  z := 0',
+        '  foreach (x,y) in [] {',
+        '    z := z + x * y',
+        '  }',
+        '  return (z)',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(new ValueInteger(0));
+    });
+
+    it('Foreach (destructuring): unbind variables -- non-empty list', () => {
+      let result = () => new Runner().run([
+        '/*@LANGUAGE@DestructuringForeach@*/',
+        'program {',
+        '  z := [1,2,3]',
+        '  foreach (x,y) in [] {',
+        '    z := z + x * y',
+        '  }',
+        '  return (y)',
+        '}',
+      ].join('\n'));
+      expect(result).throws(i18n('errmsg:undefined-variable')('y'));
+    });
+
   });
 
   describe('Statements: while', () => {


### PR DESCRIPTION
Se implementaron:

- La versión destructuring del foreach, que permite escribir cualquier patrón en el lugar del índice. Esto incluye tuplas `foreach (x, y) in [(1,2),(3,4)] { ... }`, comodines `foreach _ in [1,2,3] { ... }`, registros `foreach Coord(x, y) in [Coord(x <- 1, y <- 2)] { ... }` y en general cualquier otro patrón. Si el elemento de alguna iteración no encaja con el patrón, se obtiene un error en tiempo de ejecución. Esta feature es experimental y solamente se encuentra habilitada si el programa incluye la directiva `/*@LANGUAGE@DestructuringForeach@*/`.

- La elipsis a nivel comando y expresión. La elipsis se representa con el token `...` (puntos suspensivos) y es equivalente a hacer `BOOM("El programa todavía está incompleto.")` para comandos, o  `boom("El programa todavía está incompleto.")` para expresiones. Por ejemplo `function f() { return (...) } program { x := f() }`