### PR TITLE
Comando TypeCheck

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -17,7 +17,7 @@ export function i18n(message) {
 
 export function i18nWithLanguage(code, thunk) {
   if (!(code in dictionaries)) {
-    throw Error('Invlid language code: ' + code);
+    throw Error('Invalid language code: ' + code);
   }
   let oldLanguage = CURRENT_LANGUAGE;
   CURRENT_LANGUAGE = code;

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -125,16 +125,16 @@ function openingDelimiterName(delimiter) {
 }
 
 function formatTypes(string, type1, type2) {
-  let result = ''
+  let result = '';
   for (let i = 0; i < string.length; i++) {
-    if (string[i] == '%' && i + 1 < string.length) {
-      if (string[i + 1] == '%') {
+    if (string[i] === '%' && i + 1 < string.length) {
+      if (string[i + 1] === '%') {
         result += '%';
         i++;
-      } else if (string[i + 1] == '1') {
+      } else if (string[i + 1] === '1') {
         result += typeAsNoun(type1);
         i++;
-      } else if (string[i + 1] == '2') {
+      } else if (string[i + 1] === '2') {
         result += typeAsNoun(type2);
         i++;
       } else {

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -636,6 +636,9 @@ export const LOCALE_ES = {
   'errmsg:cannot-divide-by-zero':
     'No se puede dividir por cero.',
 
+  'errmsg:negative-exponent':
+    'El exponente de la potencia no puede ser negativo.',
+
   'errmsg:list-cannot-be-empty':
     'La lista no puede ser vacía.',
 

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -124,6 +124,29 @@ function openingDelimiterName(delimiter) {
   }
 }
 
+function formatTypes(string, type1, type2) {
+  let result = ''
+  for (let i = 0; i < string.length; i++) {
+    if (string[i] == '%' && i + 1 < string.length) {
+      if (string[i + 1] == '%') {
+        result += '%';
+        i++;
+      } else if (string[i + 1] == '1') {
+        result += typeAsNoun(type1);
+        i++;
+      } else if (string[i + 1] == '2') {
+        result += typeAsNoun(type2);
+        i++;
+      } else {
+        result += '%';
+      }
+    } else {
+      result += string[i];
+    }
+  }
+  return result;
+}
+
 export const LOCALE_ES = {
 
   /* Descriptions of syntactic constructions and tokens */
@@ -648,6 +671,12 @@ export const LOCALE_ES = {
            + millisecs.toString() + 'ms.';
     },
 
+  /* Typecheck */
+  'errmsg:typecheck-failed':
+    function (errorMessage, type1, type2) {
+      return formatTypes(errorMessage, type1, type2);
+    },
+
   /* Board operations */
   'errmsg:cannot-move-to':
     function (dirName) {
@@ -688,6 +717,7 @@ export const LOCALE_ES = {
   'CONS:Dir2': 'Sur',
   'CONS:Dir3': 'Oeste',
 
+  'PRIM:TypeCheck': 'TypeCheck',
   'PRIM:BOOM': 'BOOM',
   'PRIM:boom': 'boom',
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -944,6 +944,20 @@ export class RuntimePrimitives {
         }
       );
 
+    this._primitiveFunctions['^'] =
+      new PrimitiveOperation(
+        [typeInteger, typeInteger],
+        function (startPos, endPos, globalState, args) {
+          let b = args[1];
+          if (b.lt(new ValueInteger(0))) {
+            fail(startPos, endPos, 'negative-exponent', []);
+          }
+        },
+        function (globalState, a, b) {
+          return a.pow(b);
+        }
+      );
+
     this._primitiveFunctions['-(unary)'] =
       new PrimitiveOperation(
         [typeAny],

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -604,6 +604,26 @@ export class RuntimePrimitives {
 
     /* --Primitive procedures-- */
 
+    this._primitiveProcedures[i18n('PRIM:TypeCheck')] =
+      new PrimitiveOperation(
+        [typeAny, typeAny, typeString],
+        function (startPos, endPos, globalState, args) {
+          let v1 = args[0];
+          let v2 = args[1];
+          let errorMessage = args[2];
+          if (joinTypes(v1.type(), v2.type()) === null) {
+            fail(startPos, endPos, 'typecheck-failed', [
+                errorMessage.string,
+                v1.type(),
+                v2.type(),
+            ]);
+          }
+        },
+        function (globalState, color) {
+          return null;
+        }
+      );
+
     this._primitiveProcedures[i18n('PRIM:PutStone')] =
       new PrimitiveOperation(
         [typeColor()], noValidation,

--- a/src/value.js
+++ b/src/value.js
@@ -547,6 +547,13 @@ export class ValueInteger extends Value {
     return this.sub(q.mul(other));
   }
 
+  /* Assumes that 'other' is non-negative */
+  pow(other) {
+    let a = Integer(this._number);
+    let b = Integer(other._number);
+    return new ValueInteger(a.pow(b).toString());
+  }
+
   eq(other) {
     return this.equal(other);
   }

--- a/test/09.builtins.spec.js
+++ b/test/09.builtins.spec.js
@@ -1297,6 +1297,66 @@ describe('Primitive functions, procedures and operators', () => {
       expect(result).throws(i18n('errmsg:cannot-divide-by-zero'));
     });
 
+    it('Power', () => {
+      let result = new Runner().run([
+        'program {',
+        '  return (',
+        /* Zero / zero */
+        '    0 ^ 0,',
+        /* Zero / positive */
+        '    0 ^ 1, 0 ^ 2, 0 ^ 3, 0 ^ 10,',
+        /* Positive / zero */
+        '    1 ^ 0, 2 ^ 0, 3 ^ 0, 10 ^ 0,',
+        /* Positive / positive */
+        '    1 ^ 1, 1 ^ 2, 1 ^ 3, 1 ^ 10,',
+        '    2 ^ 1, 2 ^ 2, 2 ^ 3, 2 ^ 10,',
+        '    3 ^ 1, 3 ^ 2, 3 ^ 3, 3 ^ 10,',
+        '    10 ^ 1, 10 ^ 2, 10 ^ 3, 10 ^ 10,',
+        /* Negative / positive */
+        '    -1 ^ 1, -1 ^ 2, -1 ^ 3, -1 ^ 10,',
+        '    -2 ^ 1, -2 ^ 2, -2 ^ 3, -2 ^ 10,',
+        '    -3 ^ 1, -3 ^ 2, -3 ^ 3, -3 ^ 10,',
+        '    -10 ^ 1, -10 ^ 2, -10 ^ 3, -10 ^ 10,',
+        /* Big */
+        '    4374389299929001883777 ^ 2,',
+        '    2 ^ 200',
+        '  )',
+        '}',
+      ].join('\n'));
+      expect(result).deep.equals(new ValueTuple([
+        /* Zero / zero */
+        new ValueInteger('1'),
+        /* Zero / positive */
+        new ValueInteger('0'), new ValueInteger('0'),
+        new ValueInteger('0'), new ValueInteger('0'),
+        /* Positive / zero */
+        new ValueInteger('1'), new ValueInteger('1'),
+        new ValueInteger('1'), new ValueInteger('1'),
+        /* Positive / positive */
+        new ValueInteger('1'), new ValueInteger('1'),
+        new ValueInteger('1'), new ValueInteger('1'),
+        new ValueInteger('2'), new ValueInteger('4'),
+        new ValueInteger('8'), new ValueInteger('1024'),
+        new ValueInteger('3'), new ValueInteger('9'),
+        new ValueInteger('27'), new ValueInteger('59049'),
+        new ValueInteger('10'), new ValueInteger('100'),
+        new ValueInteger('1000'), new ValueInteger('10000000000'),
+        /* Negative / positive */
+        new ValueInteger('-1'), new ValueInteger('1'),
+        new ValueInteger('-1'), new ValueInteger('1'),
+        new ValueInteger('-2'), new ValueInteger('4'),
+        new ValueInteger('-8'), new ValueInteger('1024'),
+        new ValueInteger('-3'), new ValueInteger('9'),
+        new ValueInteger('-27'), new ValueInteger('59049'),
+        new ValueInteger('-10'), new ValueInteger('100'),
+        new ValueInteger('-1000'), new ValueInteger('10000000000'),
+        /* Big */
+        new ValueInteger('19135281747333343200152945504707214615785729'),
+        new ValueInteger(
+          '1606938044258990275541962092341162602522202993782792835301376'),
+      ]));
+    });
+
   });
 
   describe('User-triggered failure (BOOM and boom)', () => {

--- a/test/09.builtins.spec.js
+++ b/test/09.builtins.spec.js
@@ -141,6 +141,32 @@ describe('Primitive functions, procedures and operators', () => {
       new ValueStructure(i18n('TYPE:Bool'), i18n('CONS:True'), {}),
     ]);
 
+  describe('Type check (TypeCheck)', () => {
+
+    describe('Typecheck passes', () => {
+      let result = new Runner().run([
+        'program {',
+        '    ' + i18n('PRIM:TypeCheck') + '(4, 0, "fail %1 %2")',
+        '}',
+      ].join(''));
+    });
+
+    describe('Typecheck fails', () => {
+      let result = () => new Runner().run([
+        'program {',
+        '    ' + i18n('PRIM:TypeCheck') +
+        '    ' + '("foo", 0, "expected %2 but got %1")',
+        '}',
+      ].join(''));
+      expect(result).throws(
+        i18n('errmsg:typecheck-failed')(
+          'expected %2 but got %1', new TypeString(), new TypeInteger()
+        )
+      );
+    });
+
+  });
+
   describe('Relational operators', () => {
 
     describe('Equality (==)', () => {
@@ -1297,7 +1323,7 @@ describe('Primitive functions, procedures and operators', () => {
       expect(result).throws(i18n('errmsg:cannot-divide-by-zero'));
     });
 
-    it('Power', () => {
+    it('Power (^)', () => {
       let result = new Runner().run([
         'program {',
         '  return (',
@@ -1355,6 +1381,15 @@ describe('Primitive functions, procedures and operators', () => {
         new ValueInteger(
           '1606938044258990275541962092341162602522202993782792835301376'),
       ]));
+    });
+
+    it('Fail on negative exponent for power (^)', () => {
+      let result = () => new Runner().run([
+        'program {',
+        '  return (2 ^ -1)',
+        '}'
+      ].join('\n'));
+      expect(result).throws(i18n('errmsg:negative-exponent'));
     });
 
   });


### PR DESCRIPTION
Se agregó el operador de potencia (^) que faltaba.

---

Se agregó el comando `TypeCheck`. Recibe tres parámetros. Los primeros son dos valores arbitrarios y el tercero es un mensaje de error (string). Si los valores tienen tipos compatibles, el comando no tiene efecto. Si los valores no tienen tipos compatibles, el comando falla con el mensaje de error provisto.

El mensaje de error puede incluir las secuencias de escape `%1` y `%2` para referirse al tipo de su primer o su segundo parámetro respectivamente. También se puede usar `%%` para escribir un porcentaje.

Ejemplo de uso:
```
function f(x) {
    TypeCheck(x, 0, "Se esperaba un número pero se recibió %1.")
    return (x + 1)
}
```