### PR TITLE
Fixes 2018 10

### DIFF
--- a/doc/05-builtins.json
+++ b/doc/05-builtins.json
@@ -136,6 +136,10 @@
     "",
     "Denota la máxima dirección."
   ],
+  ["function", "esVacía", ["lista"],
+    "",
+    "Denota verdadero si la lista es vacía."
+  ],
   ["function", "primero", ["lista"],
     "La lista no puede ser vacía.",
     "Denota la cabeza de la lista, es decir, su primer elemento."
@@ -148,7 +152,7 @@
     "La lista no puede ser vacía.",
     "Denota el comienzo de la lista, es decir, la lista que consta de todos los elementos excepto el último."
   ],
-  ["function", "ultimo", ["lista"],
+  ["function", "último", ["lista"],
     "La lista no puede ser vacía.",
     "Denota el último elemento de la lista."
   ]

--- a/doc/05-builtins.tex
+++ b/doc/05-builtins.tex
@@ -149,6 +149,10 @@
 \begin{itemize}
 \item {\bf Prop\'osito:} Denota la m\'axima direcci\'on.
 \end{itemize}
+\item \texttt{function} \typename{esVac\'ia}(lista)
+\begin{itemize}
+\item {\bf Prop\'osito:} Denota verdadero si la lista es vac\'ia.
+\end{itemize}
 \item \texttt{function} \typename{primero}(lista)
 \begin{itemize}
 \item {\bf Precondici\'on:} La lista no puede ser vac\'ia.
@@ -164,7 +168,7 @@
 \item {\bf Precondici\'on:} La lista no puede ser vac\'ia.
 \item {\bf Prop\'osito:} Denota el comienzo de la lista, es decir, la lista que consta de todos los elementos excepto el \'ultimo.
 \end{itemize}
-\item \texttt{function} \typename{ultimo}(lista)
+\item \texttt{function} \typename{\'ultimo}(lista)
 \begin{itemize}
 \item {\bf Precondici\'on:} La lista no puede ser vac\'ia.
 \item {\bf Prop\'osito:} Denota el \'ultimo elemento de la lista.

--- a/doc/gendoc.py
+++ b/doc/gendoc.py
@@ -209,7 +209,7 @@ def builtin_routine_to_tex(builtin):
     parameters = builtin[2]
     tex.append(
       '\\item \\texttt{%s} \\typename{%s}(%s)' % (
-        builtin[0], builtin[1], ', '.join(parameters)
+        builtin[0], string_to_tex(builtin[1]), ', '.join(parameters)
       )
     )
     tex.append('\\begin{itemize}')

--- a/doc/gobstones.tex
+++ b/doc/gobstones.tex
@@ -510,10 +510,10 @@ La etapa de an\'alisis sem\'antico (o {\em linting}) verifica de manera est\'ati
       \item Un patr\'on estructura y un patr\'on tupla.
       \end{itemize}
 \item Los patrones de las ramas del \texttt{interactive program}
-      \DEBEN ser eventos, es decir:
+      \DEBEN ser eventos y \NOPUEDEN ser patrones variable, es decir,
+      pueden ser
       patrones timeout,
-      patrones estructura del tipo \texttt{\_EVENT},
-      patrones variable
+      patrones estructura del tipo \texttt{\_EVENT}
       o patrones comod\'in.
 \item Los patrones de las ramas de los \texttt{switch} y los \texttt{matching..select} \NOPUEDEN ser eventos, es decir:
       pueden ser

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -499,6 +499,9 @@ export const LOCALE_ES = {
   'errmsg:patterns-in-interactive-program-must-be-events':
     'Los patrones de un "interactive program" deben ser eventos.',
 
+  'errmsg:patterns-in-interactive-program-cannot-be-variables':
+    'El patrón no puede ser una variable.',
+
   'errmsg:patterns-in-switch-must-not-be-events':
     'El patrón no puede ser un evento.',
 
@@ -771,7 +774,7 @@ export const LOCALE_ES = {
   'PRIM:minDir': 'minDir',
   'PRIM:maxDir': 'maxDir',
 
-  'PRIM:isEmpty': 'vacía',
+  'PRIM:isEmpty': 'esVacía',
   'PRIM:head': 'primero',
   'PRIM:tail': 'resto',
   'PRIM:init': 'comienzo',

--- a/src/linter.js
+++ b/src/linter.js
@@ -100,6 +100,7 @@ export class Linter {
       'structure-pattern-repeats-timeout': true,
       'pattern-does-not-match-type': true,
       'patterns-in-interactive-program-must-be-events': true,
+      'patterns-in-interactive-program-cannot-be-variables': true,
       'patterns-in-switch-must-not-be-events': true,
       'patterns-in-foreach-must-not-be-events': true,
       'repeated-variable-in-tuple-assignment': true,
@@ -521,6 +522,12 @@ export class Linter {
         this._lintCheck(
           branch.pattern.startPos, branch.pattern.endPos,
           'patterns-in-interactive-program-must-be-events', []
+        );
+      }
+      if (branch.pattern.tag === N_PatternVariable) {
+        this._lintCheck(
+          branch.pattern.startPos, branch.pattern.endPos,
+          'patterns-in-interactive-program-cannot-be-variables', []
         );
       }
     }

--- a/test/05.linter.spec.js
+++ b/test/05.linter.spec.js
@@ -1312,6 +1312,17 @@ describe('Linter', () => {
       );
     });
 
+    it('Reject variable patterns in interactive program', () => {
+      let code = [
+        'interactive program {',
+        '  k -> {}',
+        '}',
+      ].join('\n');
+      expect(() => lint(code)).throws(
+        i18n('errmsg:patterns-in-interactive-program-cannot-be-variables')
+      );
+    });
+
     it('Reject repeated parameter names in structure pattern', () => {
       let code = [
         'type A is record {',


### PR DESCRIPTION
Pequeños cambios:
- Se renombró la función que determina si una lista es vacía de `vacía` a `esVacía`.
- Se prohíbe la presencia de patrones variable en el interactive program. P.ej. `interactive program { k -> { } }` se rechaza.
- (Se actualizó la documentación).